### PR TITLE
fix(apache): remove unnecessary alias

### DIFF
--- a/config/apache.conf
+++ b/config/apache.conf
@@ -1,7 +1,6 @@
 # from https://gitlab.com/davical-project/davical/-/blob/e8b43e60dbbd7bf6860b00a820556ef484aca9e5/config/apache-davical.conf
 
 ServerName ${HOST_NAME}
-Alias /davical /usr/share/davical/htdocs
 
 <VirtualHost *:80>
     DocumentRoot /usr/share/davical/htdocs
@@ -23,12 +22,12 @@ Alias /davical /usr/share/davical/htdocs
 
     # PT is important if you are using an alias, it implies L
     # Redirect /.well-known URLs
-    RewriteRule ^/\.well-known/(.*)$ /davical/caldav.php/.well-known/$1 [NC,PT]
+    RewriteRule ^/\.well-known/(.*)$ /caldav.php/.well-known/$1 [NC,PT]
     # Optionally: redirect /principals/users/ as well
-    RewriteRule ^/principals/users/(.*)$ /davical/caldav.php/$1 [NC,PT]
-    RewriteRule ^/principals/resources/(.*)$ /davical/caldav.php/$1 [NC,PT]
-    RewriteRule ^/calendars/__uids__/(.*)$ /davical/caldav.php/$1 [NC,PT]
-    RewriteRule ^/addressbooks/__uids__/(.*)$ /davical/caldav.php/$1 [NC,PT]
+    RewriteRule ^/principals/users/(.*)$ /caldav.php/$1 [NC,PT]
+    RewriteRule ^/principals/resources/(.*)$ /caldav.php/$1 [NC,PT]
+    RewriteRule ^/calendars/__uids__/(.*)$ /caldav.php/$1 [NC,PT]
+    RewriteRule ^/addressbooks/__uids__/(.*)$ /caldav.php/$1 [NC,PT]
 
     # Optionally: Put DAViCal in the root
     # NOTE: this will break other applications that rely on mod_rewrite!
@@ -36,11 +35,10 @@ Alias /davical /usr/share/davical/htdocs
     # Not if it's the root URL.  You might want to comment this out if you
     # want to use an explicit /index.php for getting to the admin pages.
     RewriteCond %{REQUEST_URI} !^/$
-    RewriteCond %{REQUEST_URI} !^/davical/$
     #
     # Not if it explicitly specifies a .php program, html page, stylesheet or image
     RewriteCond %{REQUEST_URI} !\.(php|html|css|js|png|gif|jpg|ico)
     #
     # Everything else gets rewritten to /caldav.php/...
-    RewriteRule ^(.*)$ /davical/caldav.php$1  [NC,L]
+    RewriteRule ^(.*)$ /caldav.php$1  [NC,L]
 </VirtualHost>


### PR DESCRIPTION
After using the image, I realized having both `DocumentRoot` and `Alias` are redundant, as it means that URLs unnecessarily have two locations (e.g. /index.php --> /davical/index.php). This is not necessarily an issue, but can cause a mismatch between created resources and returned resources. For example, creating `http://localhost:4080/caldav.php/admin/notifications/` will then return a created resource at `http://localhost:4080/davical/caldav.php/admin/notifications/`.