### PR TITLE
docs: specify Postgres 13 in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: postgres:alpine
+    image: postgres:13-alpine
     ports:
       - '5432:5432'
     environment:


### PR DESCRIPTION
Since this image was published, PostgreSQL 15 has been released, and it appears that version 1.1.10 of DAViCal is not compatible. In fact, officially only versions up to 13 are supported. So, update the docker-compose documentation to specify version 13 of PostgreSQL.

Closes #5 