### PR TITLE
ci: fix curl and release rules

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,9 +99,8 @@ build:
 release:
   extends:
     - .release-image
-    - .only-commits
   rules:
-    - if: "$CI_COMMIT_BRANCH == 'main'"
+    - if: "$CI_COMMIT_BRANCH == 'main' && $CI_PIPELINE_SOURCE != 'schedule'"
 
 ##
 ## Nightly pipelines
@@ -115,9 +114,7 @@ prepare-nightly:
   extends:
     - .only-nightly
   stage: build
-  image:
-    name: curlimages/curl # only curl is needed for get-release-sha
-    entrypoint: ["sh"]
+  image: curlimages/curl # only curl is needed for get-release-sha
   script:
     # sets DOCKER_BUILD_FLAGS and BUILD_PREFIX to the latest master commit of DAViCal and AWL
     - ./helpers/get-release-sha.sh master master


### PR DESCRIPTION
Fixes two issues [in the schedules pipeline](https://gitlab.com/fintechstudios/davical-docker/-/pipelines/726797635):
1. The `curlimages/curl` entrypoint prevents the image from working in GitLab CI.
2. The `rules` in `release` act as logical OR, not logical AND, so the `release` was running for schedules and commits. Updates The `rules` to combine them in the same `if`.