### PR TITLE
ci: fix release SHA helper

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,6 +116,7 @@ prepare-nightly:
   stage: build
   image: curlimages/curl # only curl is needed for get-release-sha
   script:
+    - apk add --no-cache jq
     # sets DAVICAL_VERSION, DAVICAL_SHA512, AWL_VERSION, and AWL_SHA512 to the latest master commit of DAViCal and AWL
     - ./helpers/get-release-sha.sh master master
   artifacts:


### PR DESCRIPTION
The GitLab `/archive/` endpoint will return a different bundle when a commit hash is specified. This means that if "master" is used to download the archive, and then the same commit hash from that download is used to download a separate archive, the shasum of both archives will not match.

As a result, the nightly build fails, since the shasum is computed by downloading the "master" archive, but the image is built using the commithash. This resolves the issue by explicitly fetching the latest commit hash for master BEFORE computing the shasum of the archive.