### PR TITLE
feat: add php-calendar library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN buildDeps="\
         pgsql \
         pdo_pgsql \
         imap \
+        calendar \
     # configure apache
     && a2enmod rewrite \
     && rm /etc/apache2/sites-enabled/000-default.conf \


### PR DESCRIPTION
Adds the php-calendar library shown in the following screenshot.

![Screenshot of Davical showing the list of PHP extensions](https://user-images.githubusercontent.com/27725238/219846458-1d3b209f-ef77-47df-b9af-f2f1f7bbe6bc.png)

It seems to be used with the function `cal_days_in_month` ([search](https://gitlab.com/search?search=cal_days_in_month&nav_source=navbar&project_id=36163&group_id=25439&search_code=true&repository_ref=master) | [file](https://gitlab.com/davical-project/davical/-/blob/master/inc/RRule.php#L969))

```php
    $days_in_month = cal_days_in_month(CAL_GREGORIAN, $first_of_month->format('m'), $first_of_month->format('Y'));
```