### PR TITLE
ci: fix latest release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,21 +85,25 @@ stages:
 ## Commit pipelines
 ##
 
-.only-commits:
-  rules:
-    - if: "$CI_PIPELINE_SOURCE != 'schedule'"
+.build-prefix-latest:
   variables:
     # this string is used in ./helpers/get-image-tags.sh and must be synced if changed
     BUILD_PREFIX: "latest"
 
+.only-commits:
+  rules:
+    - if: "$CI_PIPELINE_SOURCE != 'schedule'"
+
 build:
   extends:
     - .build-image
+    - .build-prefix-latest
     - .only-commits
 
 release:
   extends:
     - .release-image
+    - .build-prefix-latest
   rules:
     - if: "$CI_COMMIT_BRANCH == 'main' && $CI_PIPELINE_SOURCE != 'schedule'"
 


### PR DESCRIPTION
Seems I [accidentally dropped the `BUILD_PREFIX` in the `release` job](https://gitlab.com/fintechstudios/davical-docker/-/jobs/3807546511) while I was rearranging for the nightly builds, and we haven't had a non-nightly release since then.