### PR TITLE
fix(migrations): run DB patches

### DIFF
--- a/bin/run-migrations
+++ b/bin/run-migrations
@@ -45,7 +45,6 @@ run_migrations() {
     --dbhost $PGHOST \
     --dbpass $DBA_PGPASSWORD \
     --appuser $DAVICAL_PGUSER \
-    --nopatch \
     --owner $DBA_PGUSER
 }
 


### PR DESCRIPTION
The `run_migrations` script currently has the `--nopatch` flag, which means it doesn't fully apply the necessary migrations. I'm uncertain why I added this flag originally, but reading the docs it seems like a mistake to have included it. See https://gitlab.com/davical-project/davical/-/blob/de29c6c6ee0572a75f4d362c1aaed256e9458045/dba/update-davical-database#L440